### PR TITLE
Changing fileupload size from 10mb to 25mb

### DIFF
--- a/app/scripts/common/models/file-upload.js
+++ b/app/scripts/common/models/file-upload.js
@@ -38,7 +38,7 @@ angular.module('dmc.model.fileUpload', ['dmc.data'])
 
               //File Size Check
               if(file.size > 25585760) {
-                toastModel.showToast('error','Sorry, file size must be under 10MB');
+                toastModel.showToast('error','Sorry, file size must be under 25MB');
                 return null;
               }
 

--- a/app/scripts/common/models/file-upload.js
+++ b/app/scripts/common/models/file-upload.js
@@ -37,7 +37,7 @@ angular.module('dmc.model.fileUpload', ['dmc.data'])
               console.log('file name: ' + file.name, name);
 
               //File Size Check
-              if(file.size > 10585760) {
+              if(file.size > 25585760) {
                 toastModel.showToast('error','Sorry, file size must be under 10MB');
                 return null;
               }


### PR DESCRIPTION
The default limit of AWS.S3 module is 5gb. From what I see of the code we prevalidate the size of every file upload in a if conditional. I have changed that from 10MB to 25MB.

For future reference if we really don't want this handled by the code we would have to change the code to have file-uploads handled in a traditional HTML FORM and use a S3 policy document to control the size. from there in the poilicy document we can use a setting known as content-length-range.

More information can be found: https://aws.amazon.com/articles/1434