### PR TITLE
Run service return handling

### DIFF
--- a/app/scripts/project/controllers/run-service.js
+++ b/app/scripts/project/controllers/run-service.js
@@ -133,8 +133,12 @@ angular.module('dmc.project')
               var handleBarHtml;
               var compiledHtml;
 
-              for(var inKey in $scope.service.interfaceModel.inParams){
-                context[inKey] = $scope.service.interfaceModel.inParams[inKey].value;
+              for(var key in $scope.service.interfaceModel.inParams){
+                try{
+                  context[key] = JSON.parse($scope.service.interfaceModel.inParams[key].value);
+                }catch(e){
+                  context[key] = $scope.service.interfaceModel.inParams[key].value;
+                }
               }
               for (var outKey in $scope.service.interfaceModel.outParams){
 		try{


### PR DESCRIPTION
**_Forewarning_** - this small change has not been tested. I don't work at UILabs so I don't have a development environment set up. FYI I'm developing services on the dev-web3 site and noticed this issue.

Regarding /app/scripts/project/controllers/run-service.js

The **updateCustomUIForInputs** function parses $scope.service.interfaceModel.inParams as json if applicable. The handlebars template "inputTemplate" can use these as objects.

After the service is run, **updateCustomUIForOutputs** does not parse the same variables as json, the json variables are left as strings. Thus the json variables are being treated as strings instead of objects in the "outputTemplate" handlebars template.