### PR TITLE
fixes in html for IE 11

### DIFF
--- a/app/styles/modules/_contact-us.scss
+++ b/app/styles/modules/_contact-us.scss
@@ -9,7 +9,7 @@
     background-color: #d9d9d9;
     font-size: 18px;
     color: #333;
-    padding: 25px 0;
+    padding: 50px 0px 20px 0px;
     div {
       margin: 0 auto;
       max-width: 1280px;

--- a/app/templates/about/about.html
+++ b/app/templates/about/about.html
@@ -1,6 +1,6 @@
 <div class="onboarding-home">
 	<md-content layout layout-align="center center">
-		<div layout="column"  layout-fills>
+		<div layout="column"  layout-fills style="max-width:98%">
 
 
 			<div layout="column" class="background">
@@ -17,11 +17,11 @@
 
 				<div class="section" layout="row" layout-align="center center" layout-fills >
 
-					<div layout="column" flex class="text">
-						
+					<div layout="column" flex class="text" style="min-width:70%">
+
 						<h2>PORTAL: <span>WHAT IS IT?</span></h2>
 						<h3>The Portal is a one-stop collaboration platform for DMDII members. It features tools that enable members to share project updates, network and collaborate on projects, stay up to date on the latest news from the Institute, and explore and learn about other members’ projects and capabilities.</h3>
-						
+
 						<p>
 
 						<h2>PORTAL: <span>WHAT TO FIND HERE</span></h2>
@@ -38,16 +38,16 @@
 						<ul>
 							On the Portal’s project page, you’ll find information about ongoing DMDII projects. You’ll be able to download final reports and source code from completed DMDII projects, and catch the latest updates on the more than 60 projects underway at DMDII.
 						</ul>
-						
+
 						<p>
-						
+
 						<h2>PORTAL: <span>GETTING ACCESS</span></h2>
 						<h3>If you’re not a DMDII member, you cannot have access to the DMDII member portal, which is too bad, because DMDII membership is awesome! Interested in joining the more-than-300-strong institute? Shoot us an email at <a href="mailto:collaborate@uilabs.org">collaborate@uilabs.org</a>!</h3>
 						<h3>If you are a member, keep reading!</h3>
 						<h3>Each membership organization has an administrator who will need to approve your access. To find out who your administrator is, click My Organization and look for members who have the green ‘ADMIN’ box inside their user card. If your organization has not yet appointed an administrator, please email <a href="askdmc@uilabs.org">askdmc@uilabs.org</a> and let us know who you would like as your administrator so our helpdesk can begin the process of setting up your organization.</h3>
 
 						<p>
-						
+
 						<h2>PORTAL: <span>GETTING STARTED</span></h2>
 						<h4>Creating a Profile</h4>
 						<ul>
@@ -71,7 +71,7 @@
 						<ul>
 							Check back often for the latest news, discussions, and project updates posted to the Portal!
 						</ul>
-						
+
 
 					</div>
 

--- a/app/templates/onboarding/home.html
+++ b/app/templates/onboarding/home.html
@@ -1,6 +1,6 @@
 <div class="onboarding-home">
 	<md-content layout layout-align="center center">
-		<div layout="column"  layout-fills>
+		<div layout="column"  layout-fills style="max-width:98%">
 
 
 			<div layout="column" class="background">

--- a/app/templates/security/security.html
+++ b/app/templates/security/security.html
@@ -163,8 +163,10 @@
 					<div layout="column" flex class="text-center">
 							<h1>Security questions or issues?</h1>
 
-							<a href="/contact-us.php" class="btn btn-next" role="button">Contact Us</a>
-							<!-- <h3><p><span class="button-view-opportunities"><a href="/contact-us.php">Contact Us</a></span></h3> -->
+              <div style="text-align:center">
+                <a href="/contact-us.php" class="btn btn-next" role="button">Contact Us</a>
+              </div>
+              <!-- <h3><p><span class="button-view-opportunities"><a href="/contact-us.php">Contact Us</a></span></h3> -->
 							<h3>If you think you may have found a security vulnerability within DMC,</h3>
 							<h3>please email us at <a href="mailto:askdmc@uilabs.org">askdmc@uilabs.org</a> with the subject line "Security".</h3>
 					</div>


### PR DESCRIPTION
For IE 11:
- DMDII portal about page looks as it should now (proper width)
- "About the DMC" page has proper width now (no horizontal scroll bar)
- Contact Us button at bottom of Security page has proper width

Other static pages seem to be okay in IE 11 (Academia, FAQ, Legal).