### PR TITLE
Added new endpoint /accounts/{id}/servers, changed getChildren to pass ID instead of IP

### DIFF
--- a/app/scripts/common/factory/data.factory.js
+++ b/app/scripts/common/factory/data.factory.js
@@ -721,6 +721,9 @@ angular.module('dmc.data', [])
       getAccountServersUrl: function(id) {
         return localhost + 'accounts/' + id + '/account_servers';
       },
+      getServerSecureUrl: function(id) {
+        return localhost + 'accounts/' + id + '/servers';
+      },
       // ---------------------------
       getServices: function(projectId) {
         if (projectId) {

--- a/app/scripts/project/controllers/upload-service.js
+++ b/app/scripts/project/controllers/upload-service.js
@@ -60,7 +60,7 @@ angular.module('dmc.project')
 
             // get servers
             function getServers(){
-                serviceModel.get_servers(function(data){
+                serviceModel.get_servers_secure(function(data){
                     $scope.servers = data;
                     apply();
                 });
@@ -79,7 +79,7 @@ angular.module('dmc.project')
             $scope.selectItemDropDown = function(value){
                 if(value != 0 || $scope.serverModel !== 0) {
                     var item = $scope.servers[value];
-                    $scope.selectedServerIp = item.ip;
+                    $scope.selectedServerIp = item.id;
                     $scope.servers.splice(value, 1);
                     $scope.servers = $scope.servers.sort(function(a,b){return a.id - b.id});
                     if ($scope.servers.unshift(item)) this.serverModel = 0;

--- a/app/scripts/project/project.js
+++ b/app/scripts/project/project.js
@@ -1047,14 +1047,14 @@ angular.module('dmc.project', [
             };
 
             this.get_service_run_history = function(id, params, callback){
-                
+
                 return $http.get(dataFactory.services(id).get_run_history, (params)? params : {
                     _sort: 'id',
                     _order: 'DESC',
                     status_ne : 'running'
                 }, {}).then(function(response){
                     var history = response.data;
-                    
+
                     for (var i = 0; i < history.length; i++) {
                         history[i].runTime = calcRunTime(history[i]);
                         history[i].date = moment(new Date(history[i].startDate+' '+history[i].startTime)).format('MM/DD/YYYY hh:mm A');
@@ -1066,9 +1066,9 @@ angular.module('dmc.project', [
                         };
                         userName(i);
                     }
-                    
+
                     return history;
-                    
+
                 });
             };
 
@@ -1076,6 +1076,15 @@ angular.module('dmc.project', [
 
             this.get_servers = function(callback){
                 return ajax.get(dataFactory.getAccountServersUrl($rootScope.userData.accountId),
+                    {},
+                    function(response){
+                        callback(response.data)
+                    }
+                )
+            };
+
+            this.get_servers_secure = function(callback){
+                return ajax.get(dataFactory.getServerSecureUrl($rootScope.userData.accountId),
                     {},
                     function(response){
                         callback(response.data)

--- a/jsonserver/stubs/servers.json
+++ b/jsonserver/stubs/servers.json
@@ -1,0 +1,74 @@
+[
+	{
+		"name": "amazonaws",
+		"accountId": 1,
+		"status": "offline",
+		"id": 1
+	},
+	{
+		"name": "Test Server",
+		"accountId": 1,
+		"status": "offline",
+		"id": 2
+	},
+	{
+		"name": "test server name",
+		"accountId": 1,
+		"status": "offline",
+		"id": 3
+	},
+	{
+		"name": "Add server for testing",
+		"accountId": 1,
+		"status": "offline",
+		"id": 4
+	},
+	{
+		"name": "test1",
+		"accountId": 1,
+		"status": "offline",
+		"id": 5
+	},
+	{
+		"name": "test111222",
+		"accountId": 1,
+		"status": "offline",
+		"id": 6
+	},
+	{
+		"name": "Add server for testing",
+		"accountId": 1,
+		"status": "offline",
+		"id": 7
+	},
+	{
+		"name": "Add server for testing0000",
+		"accountId": 1,
+		"status": "offline",
+		"id": 8
+	},
+	{
+		"name": "Add server for testing0000 rename",
+		"accountId": 1,
+		"status": "offline",
+		"id": 9
+	},
+	{
+		"name": "Add server for testing0000 rename",
+		"accountId": 1,
+		"status": "offline",
+		"id": 10
+	},
+	{
+		"name": "Add server for testing0000 rename",
+		"accountId": 1,
+		"status": "offline",
+		"id": 11
+	},
+	{
+		"name": "Add server for testing0000 rename",
+		"accountId": 1,
+		"status": "offline",
+		"id": 12
+	}
+]


### PR DESCRIPTION
/accounts/{id}/servers will return DOMEServer information without the IP included. getChildren will be passed ID of DOMEServer instead of IP to attempt to mask IP from client.

DEPENDENT ON DMCREST PULL REQUESTED TITLED "New endpoint /accounts/{id}/servers to get DOMEServer without IP"